### PR TITLE
fix(coop/crazier-box): change blind shot trigger to lights out

### DIFF
--- a/Coop/06_art-therapy/09_crazier-box.cfg
+++ b/Coop/06_art-therapy/09_crazier-box.cfg
@@ -5,7 +5,7 @@ sar_speedrun_cc_rule "Cube Preserve" zone center=64,416,768 size=64,192,256 angl
 sar_speedrun_cc_rule "Cube Receptacle" entity targetname=team_trigger_door inputname=Enable
 sar_speedrun_cc_rule "Door Trigger Blue" entity targetname=team_door-team_proxy inputname=OnProxyRelay1
 sar_speedrun_cc_rule "Door Trigger Orange" entity targetname=team_door-team_proxy inputname=OnProxyRelay3
-sar_speedrun_cc_rule "Blind Shot" entity targetname=bts_wall_undamaged inputname=Disable
+sar_speedrun_cc_rule "Door Activation" entity targetname=@exit_door inputname=Open // This is tied to lights out (704 ticks between)
 sar_speedrun_cc_rule "Flags 1" flags
 sar_speedrun_cc_rule "Flags 2" flags "ccafter=Flags 1" action=stop
 


### PR DESCRIPTION
According to Rex, the Blind Shot trigger provides an advantage
unity suggested when lights go off, I agree

I love PR for a single line change <3
push access pls ty