### PR TITLE
fix(coop/crazier-box): remove blind shot trigger

### DIFF
--- a/Coop/06_art-therapy/09_crazier-box.cfg
+++ b/Coop/06_art-therapy/09_crazier-box.cfg
@@ -5,7 +5,6 @@ sar_speedrun_cc_rule "Cube Preserve" zone center=64,416,768 size=64,192,256 angl
 sar_speedrun_cc_rule "Cube Receptacle" entity targetname=team_trigger_door inputname=Enable
 sar_speedrun_cc_rule "Door Trigger Blue" entity targetname=team_door-team_proxy inputname=OnProxyRelay1
 sar_speedrun_cc_rule "Door Trigger Orange" entity targetname=team_door-team_proxy inputname=OnProxyRelay3
-sar_speedrun_cc_rule "Blind Shot" entity targetname=bts_wall_undamaged inputname=Disable
 sar_speedrun_cc_rule "Flags 1" flags
 sar_speedrun_cc_rule "Flags 2" flags "ccafter=Flags 1" action=stop
 


### PR DESCRIPTION
Rex says that this trigger provides an advantage
unity suggests when lights go off, that's already tied to Door Trigger Orange so ye