### PR TITLE
Door trigger on Turret Blocker acts like a door passthrough trigger

### DIFF
--- a/portal2/sp/03_the-return/07_turret-blocker.cfg
+++ b/portal2/sp/03_the-return/07_turret-blocker.cfg
@@ -1,7 +1,8 @@
 sar_speedrun_cc_start "Turret Blocker" map=sp_a2_turret_blocker action=split
 
 sar_speedrun_cc_rule "Start" load action=force_start
-sar_speedrun_cc_rule "Door Trigger" entity targetname=info_sign-proxy inputname=OnProxyRelay1
+sar_speedrun_cc_rule "Door Trigger" entity targetname=door_0-proxy inputname=OnProxyRelay2
+sar_speedrun_cc_rule "Door Passthrough" entity targetname=info_sign-proxy inputname=OnProxyRelay1
 sar_speedrun_cc_rule "Turret Boost" zone center=-624,192,192 size=32,128,128 angle=0
 sar_speedrun_cc_rule "Button Activation" entity targetname=button_1-proxy inputname=OnProxyRelay9
 sar_speedrun_cc_rule "Flags" flags action=stop


### PR DESCRIPTION
Updated Turret Blocker mtriggers so the door trigger is actually accurate and not a door passthrough trigger